### PR TITLE
BUGFIX

### DIFF
--- a/frontend/src/app/about-us/account-managers/[slug]/queries.ts
+++ b/frontend/src/app/about-us/account-managers/[slug]/queries.ts
@@ -239,11 +239,11 @@ export interface AccountManager {
     }>;
     dates: {
       sameDayOneMonthAgo: string;
-      oneMonthAgo: string;
+      lastDayOfOneMonthAgo: string;
       sameDayTwoMonthsAgo: string;
-      twoMonthsAgo: string;
+      lastDayOfTwoMonthsAgo: string;
       sameDayThreeMonthsAgo: string;
-      threeMonthsAgo: string;
+      lastDayOfThreeMonthsAgo: string;
     };
     summary: {
       realized: number;


### PR DESCRIPTION
- Renamed date fields in the AccountManager interface from 'oneMonthAgo', 'twoMonthsAgo', and 'threeMonthsAgo' to 'lastDayOfOneMonthAgo', 'lastDayOfTwoMonthsAgo', and 'lastDayOfThreeMonthsAgo' for improved clarity and consistency.
- Updated corresponding references in the queries to ensure alignment with the new naming convention.