### PR TITLE
Enhance Staleliness Feature with 15-Day Case Tracking

### DIFF
--- a/backend/api/src/operational_summaries/schema.graphql
+++ b/backend/api/src/operational_summaries/schema.graphql
@@ -1,6 +1,7 @@
 type Staleliness {
     staleCases: [StalelinessCase!]!
     staleInOneWeekCases: [StalelinessCase!]!
+    staleInLessThan15DaysCases: [StalelinessCase!]!
     noDescriptionCases: [StalelinessCase!]!
     upToDateCases: [StalelinessCase!]!
 }

--- a/backend/api/src/operational_summaries/staleliness.py
+++ b/backend/api/src/operational_summaries/staleliness.py
@@ -13,6 +13,7 @@ def compute_staleliness(workerSlug: str = None):
     result = {
             'stale_cases': [],
             'stale_in_one_week_cases': [], 
+            'stale_in_less_than_15_days_cases': [],
             'no_description_cases': [],
             'up_to_date_cases': []
         }
@@ -65,6 +66,9 @@ def compute_staleliness(workerSlug: str = None):
         # Will be stale in one week (21-30 days)
         elif days_since_update and days_since_update >= 21:
             result['stale_in_one_week_cases'].append(case_dict)
+        # Will be stale in 15 days (15-20 days)
+        elif days_since_update and days_since_update >= 15:
+            result['stale_in_less_than_15_days_cases'].append(case_dict)
         # Up to date cases
         else:
             result['up_to_date_cases'].append(case_dict)
@@ -73,4 +77,3 @@ def compute_staleliness(workerSlug: str = None):
 
 def resolve_staleliness(root, info):
     return compute_staleliness()
-    

--- a/frontend/src/app/about-us/consultants-and-engineers/[slug]/page.tsx
+++ b/frontend/src/app/about-us/consultants-and-engineers/[slug]/page.tsx
@@ -65,6 +65,11 @@ const CaseStatusOverview = ({ staleliness }: { staleliness: any }) => (
         color="text-green-600"
       />
       <CaseStatusCard 
+        title="Stale in Less Than 15 Days" 
+        cases={staleliness.staleInLessThan15DaysCases}
+        color="text-yellow-600"
+      />
+      <CaseStatusCard 
         title="Stale in One Week" 
         cases={staleliness.staleInOneWeekCases}
         color="text-yellow-600"
@@ -73,11 +78,6 @@ const CaseStatusOverview = ({ staleliness }: { staleliness: any }) => (
         title="Stale Cases" 
         cases={staleliness.staleCases}
         color="text-red-600"
-      />
-      <CaseStatusCard 
-        title="No Description" 
-        cases={staleliness.noDescriptionCases}
-        color="text-gray-600"
       />
     </div>
   </div>

--- a/frontend/src/app/about-us/consultants-and-engineers/[slug]/queries.ts
+++ b/frontend/src/app/about-us/consultants-and-engineers/[slug]/queries.ts
@@ -24,6 +24,10 @@ export const GET_CONSULTANT = gql`
           title
           slug
         }
+        staleInLessThan15DaysCases {
+          title
+          slug
+        }
         upToDateCases {
           title
           slug

--- a/frontend/src/app/operational-summaries/staleliness/page.tsx
+++ b/frontend/src/app/operational-summaries/staleliness/page.tsx
@@ -18,6 +18,7 @@ import Link from "next/link";
 const sections = [
   { id: 'staleCases', title: 'Stale Cases', subtitle: '0 cases' },
   { id: 'staleInOneWeekCases', title: 'Stale in One Week', subtitle: '0 cases' },
+  { id: 'staleInLessThan15DaysCases', title: 'Stale in Less Than 15 Days', subtitle: '0 cases' },
   { id: 'noDescriptionCases', title: 'Without Description', subtitle: '0 cases' },
   { id: 'upToDateCases', title: 'Up To Date', subtitle: '0 cases' },
 ];

--- a/frontend/src/app/operational-summaries/staleliness/query.tsx
+++ b/frontend/src/app/operational-summaries/staleliness/query.tsx
@@ -23,6 +23,16 @@ export const STALELINESS_QUERY = gql`
           slug
         }
       }
+      staleInLessThan15DaysCases {
+        title
+        slug
+        lastUpdated
+        daysSinceUpdate
+        workers {
+          name
+          slug
+        }
+      }
       noDescriptionCases {
         title
         slug

--- a/frontend/src/content/changelog/2024-12-30.mdx
+++ b/frontend/src/content/changelog/2024-12-30.mdx
@@ -1,0 +1,9 @@
+---
+title: 15-days stale cases
+date: 2024-12-30
+---
+
+### New Features
+
+- Added [15-days stale cases](/operational-summaries/staleliness) to view cases that are stale in less than 15 days.
+- Added 15-days stale cases to the [consultant's page](/about-us/consultants-and-engineers/fernando-paiva).


### PR DESCRIPTION
- Added a new field for cases stale in less than 15 days to the GraphQL schema and updated the computation logic in `staleliness.py`.
- Updated the frontend components to display the new 15-day stale cases in the operational summaries and consultant pages.
- Introduced a changelog entry documenting the addition of the 15-day stale cases feature.

These changes improve the visibility of cases approaching staleness, allowing for better tracking and management of operational summaries.