### PR TITLE
Update ActiveDeal Schema: Change clientOrProspectName to Optional

### DIFF
--- a/backend/api/src/domain/schema.graphql
+++ b/backend/api/src/domain/schema.graphql
@@ -189,7 +189,7 @@ type ActiveDeal {
   stageId: Int!
   stageName: String!
   stageOrderNr: Int!
-  clientOrProspectName: String!
+  clientOrProspectName: String
   client: Client
   accountManager: AccountManager
   sponsor: Sponsor


### PR DESCRIPTION
- Modified the `clientOrProspectName` field in the `ActiveDeal` model from required to optional, allowing for greater flexibility in deal representation.
- This change enhances the schema's adaptability to various data scenarios, improving overall data handling in the application.