### PR TITLE
fix: Handle Empty Worker Names in Revenue Tracking Calculation

### DIFF
--- a/backend/models/src/omni_models/analytics/revenue_tracking.py
+++ b/backend/models/src/omni_models/analytics/revenue_tracking.py
@@ -1444,6 +1444,7 @@ def compute_pre_contracted_revenue_tracking(df: pd.DataFrame, date_of_interest: 
         if result and len(project_df) > 0:
             by_worker = []
             for worker_name in project_df["WorkerName"].unique():
+                worker_name = worker_name if worker_name else "N/A"
                 worker_df = project_df[project_df["WorkerName"] == worker_name]
                 worker = globals.omni_models.workers.get_by_name(worker_name)
                 by_worker.append(RevenueTrackingWorker(


### PR DESCRIPTION
Update the revenue tracking computation to assign a default value of "N/A" for any empty worker names, ensuring data integrity and clarity in reporting.